### PR TITLE
Crc fix

### DIFF
--- a/simulateInputECOND.py
+++ b/simulateInputECOND.py
@@ -383,12 +383,12 @@ def make_eportRX_input(args):
                         word = header_word
                     # calculate the CRC (polynomial 0x104c11db7) for full list of daq words (input last 32 bit packet with data)
                     if word=='CRC':
-                        daqvals = [hex(int(header_word,2))[2:] if w=='HDR' else hex(int(w,2))[2:] for w in roc_buffer_by_link[event_read][link_counter][0:39]]
+                        #calculate crc based on last 39 words of the data
+                        daqvals = roc_data_by_link[link_counter][-39:]
                         import crcmod,codecs
                         crc = crcmod.mkCrcFun(0x104c11db7,initCrc=0, xorOut=0, rev=False)
                         crcword = crc(codecs.decode((''.join(daqvals)), 'hex'))
                         word = '{0:032b}'.format(crcword)
-                        # print('CRC ',crcword,hex(crcword),word)
                     # debug for elink2
                     #if link_counter==2: print(word)
                     word = '{0:08X}'.format(int(word,base=2))

--- a/simulateInputECOND.py
+++ b/simulateInputECOND.py
@@ -55,6 +55,9 @@ IDLEWORD_BC0 = '9CCCCCCC'
 IDLEWORD = 'ACCCCCCC'
 ONEWORD_HEX = 0xffffffff
 
+import crcmod,codecs
+crc = crcmod.mkCrcFun(0x104c11db7,initCrc=0, xorOut=0, rev=False)
+
 def generate_L1a_fast_commands(args):
     sequences = args.sequence.split(',')
     L1a_nums = args.nL1a.split(',')
@@ -385,8 +388,7 @@ def make_eportRX_input(args):
                     if word=='CRC':
                         #calculate crc based on last 39 words of the data
                         daqvals = roc_data_by_link[link_counter][-39:]
-                        import crcmod,codecs
-                        crc = crcmod.mkCrcFun(0x104c11db7,initCrc=0, xorOut=0, rev=False)
+
                         crcword = crc(codecs.decode((''.join(daqvals)), 'hex'))
                         word = '{0:032b}'.format(crcword)
                     # debug for elink2


### PR DESCRIPTION
Fixes a bug in crc calculation,  in current implementation `header_word` is remade every bx, and the random bits change.  This meant the value of `header_word` that went into the data stream was different than the value of `header_word` that went into the CRC.

Now, `daqvals` is taken directly as the last 39 words in the data stream, which avoids this problem.

Also, the initialization of the crc is moved to the beginning, to avoid it having to be reinitialized dozens of times (no effect on data, but would be more efficient)