### PR TITLE
update header bits on CM word

### DIFF
--- a/simulateInputECOND.py
+++ b/simulateInputECOND.py
@@ -199,7 +199,7 @@ def make_dataset(args,num_events):
                     word = 'HDR' # place-holder, so that we can replace with bx and orbit when L1A is called
                 elif word_type=='CM':
                     if args.physicsdata or args.zerodata:
-                        word = '10'
+                        word = '00'
                         word += '{0:010b}'.format(0)
                         word += '{0:010b}'.format(random.getrandbits(10)) # ADC-CM0
                         word += '{0:010b}'.format(random.getrandbits(10)) # ADC-CM1


### PR DESCRIPTION
Small update to the header of the CM word.  In the HGCROC working document v2.0, it listed the first two bits on the CM word as `10` , but it is apparently a mistake (which will be corrected in v2.1 of the document), and the bits should be `00`

https://gitlab.cern.ch/cmshgcalasic/econd_rtl/-/merge_requests/66